### PR TITLE
[#63] 리뷰 작성 에디터 렌더링 개선

### DIFF
--- a/components/ReviewRegister/ErrorMent.tsx
+++ b/components/ReviewRegister/ErrorMent.tsx
@@ -1,7 +1,7 @@
-import { IMentType } from './ReviewRegisterType';
+import { StrictPropsWithChildren } from '../../globalType';
 
-function ErrorMent({ children }: IMentType) {
-  return <p className="text-red500">{children}</p>;
+function ErrorMent({ children }: StrictPropsWithChildren) {
+  return <p className="mt-2 text-red500">{children}</p>;
 }
 
 export default ErrorMent;

--- a/components/ReviewRegister/RegisterForm.tsx
+++ b/components/ReviewRegister/RegisterForm.tsx
@@ -15,8 +15,8 @@ function RegisterForm({ reviewerId, reviewerName, reviewId, title, content, prUr
     register,
     handleSubmit,
     setValue,
-    watch,
     setError,
+    getValues,
     trigger,
     formState: { errors },
   } = useForm<IReviewRegisterType>({
@@ -72,9 +72,9 @@ function RegisterForm({ reviewerId, reviewerName, reviewId, title, content, prUr
   return (
     <>
       {loading && <Loading />}
-      <form className="flex flex-col p-3 gap-6" onSubmit={handleSubmit(reviewId ? onModifyHandler : onSubmitHandler)}>
+      <form className="flex flex-col gap-6 p-3" onSubmit={handleSubmit(reviewId ? onModifyHandler : onSubmitHandler)}>
         <div>
-          <p className="text-neutral400 text-lg">리뷰어 : {reviewerName}</p>
+          <p className="text-lg text-neutral400">리뷰어 : {reviewerName}</p>
         </div>
         <div>
           <div>
@@ -95,7 +95,7 @@ function RegisterForm({ reviewerId, reviewerName, reviewId, title, content, prUr
               })}
               placeholder="제목을 입력해주세요. 최대 50자입니다."
               maxLength={50}
-              className="p-2 w-full border-solid border-2 rounded-radius-m outline-none"
+              className="w-full p-2 border-2 border-solid outline-none rounded-radius-m"
               readOnly={reviewId ? true : false}
             />
             {errors.title && <ErrorMent>{errors.title.message}</ErrorMent>}
@@ -109,9 +109,9 @@ function RegisterForm({ reviewerId, reviewerName, reviewId, title, content, prUr
             <ReviewEditor
               setValue={setValue}
               setError={setError}
-              watch={watch}
               trigger={trigger}
               editorRef={editorRef}
+              getValue={getValues}
             />
             {errors.content && <ErrorMent>{errors.content.message}</ErrorMent>}
           </div>
@@ -134,14 +134,14 @@ function RegisterForm({ reviewerId, reviewerName, reviewId, title, content, prUr
               id="pullRequestEmail"
               type="text"
               placeholder="Pull Request URL을 입력해주세요."
-              className="p-2 w-full border-solid border-2 rounded-radius-m outline-none"
+              className="w-full p-2 border-2 border-solid outline-none rounded-radius-m"
               readOnly={reviewId ? true : false}
             />
             {errors.prUrl && <ErrorMent>{errors.prUrl.message}</ErrorMent>}
           </div>
         </div>
         <div className="flex justify-end">
-          <button className="w-40 flex justify-center items-center bg-c-black text-c-white h-10 rounded-radius-m">
+          <button className="flex items-center justify-center w-40 h-10 bg-c-black text-c-white rounded-radius-m">
             요청
           </button>
         </div>

--- a/components/ReviewRegister/ReviewEditor.tsx
+++ b/components/ReviewRegister/ReviewEditor.tsx
@@ -52,7 +52,7 @@ const formats = [
 
 const EDITORMAX = 500;
 
-function ReviewEditor({ setError, setValue, watch, trigger, editorRef }: IRegisterType) {
+function ReviewEditor({ setError, setValue, getValue, trigger, editorRef }: IRegisterType) {
   const modules = useMemo(() => editorModule, []);
 
   const editorContentChange = (content: string) => {
@@ -84,7 +84,7 @@ function ReviewEditor({ setError, setValue, watch, trigger, editorRef }: IRegist
     <div>
       <QuillEditor
         forwardedRef={editorRef}
-        value={watch('content')}
+        value={getValue('content')}
         onChange={(e) => editorContentChange(e)}
         placeholder="리뷰 받고싶은 내용을 입력해주세요. 최대 500글자까지 작성 가능합니다."
         modules={modules}

--- a/components/ReviewRegister/ReviewRegisterType.ts
+++ b/components/ReviewRegister/ReviewRegisterType.ts
@@ -1,5 +1,5 @@
 import { RefObject } from 'react';
-import { UseFormSetValue, UseFormWatch, UseFormTrigger, UseFormSetError } from 'react-hook-form';
+import { UseFormSetValue, UseFormTrigger, UseFormSetError, UseFormGetValues } from 'react-hook-form';
 import { ReactNode } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import { NextApiRequestCookies } from 'next/dist/server/api-utils';
@@ -46,9 +46,9 @@ export interface IQuillEditorType<T> {
 export interface IRegisterType {
   setValue: UseFormSetValue<IReviewRegisterType>;
   setError: UseFormSetError<IReviewRegisterType>;
-  watch: UseFormWatch<IReviewRegisterType>;
   trigger: UseFormTrigger<IReviewRegisterType>;
   editorRef: RefObject<ReactQuill>;
+  getValue: UseFormGetValues<IReviewRegisterType>;
 }
 
 export interface IMentType {

--- a/components/ReviewRegister/ReviewRegisterType.ts
+++ b/components/ReviewRegister/ReviewRegisterType.ts
@@ -1,6 +1,5 @@
 import { RefObject } from 'react';
 import { UseFormSetValue, UseFormTrigger, UseFormSetError, UseFormGetValues } from 'react-hook-form';
-import { ReactNode } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import { NextApiRequestCookies } from 'next/dist/server/api-utils';
 import ReactQuill from 'react-quill';
@@ -49,10 +48,6 @@ export interface IRegisterType {
   trigger: UseFormTrigger<IReviewRegisterType>;
   editorRef: RefObject<ReactQuill>;
   getValue: UseFormGetValues<IReviewRegisterType>;
-}
-
-export interface IMentType {
-  children: ReactNode;
 }
 
 export interface ILinkUserIdType extends ParsedUrlQuery {


### PR DESCRIPTION
## 상세 내용
- 리뷰 작성 페이지의 에디터 렌더링 개선
  - 글자 입력시 2회씩 렌더링 되는 부분 개선
  - 2회씩 렌더링 되던 이유
    - trigger 메소드 :  register로 등록된 값을 수동으로 알려주기 위한 메소드이다. 해당 메소드는 실행 될때 마다 렌더링이 일어난다.
    - watch 메소드 :  register로 등록된 값의 최신값을 알고 있는 메소드이다. 값이 변경되면 watch를 사용하는 컴포넌트는 리렌더링이 일어난다.
  - 해결책 : useForm은 getValues 라는 메소드를 제공한다. 해당 메소드는 register의 값을 가지고 있지만 렌더링이 일어나지 않는다. 그래서 값이 변경되더라도 화면에서 렌더링이 일어나지 않기 때문에 최신값이 보이지 않는다. trigger를 사용해 수동으로 값의 여부를 알려주고 있기 때문에 입력시 렌더링이 일어난다. 즉 watch를 사용해서 화면에 값을 확인하는것이 아닌 getValues를 통해 최신값을 화면에서 보여주도록 변경했다.

- ErrorMent 컴포넌트 타입 수정 